### PR TITLE
Iss3

### DIFF
--- a/message.go
+++ b/message.go
@@ -365,13 +365,20 @@ func (m *Message) encode() ([]byte, error) {
 	   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 	*/
 
+    tknlen := uint8(len(m.Token))
+    if (tknlen > 8) {
+        tknlen = 8
+    }
+
 	buf := bytes.Buffer{}
 	buf.Write([]byte{
-		(1 << 6) | (uint8(m.Type) << 4) | uint8(0xf&len(m.Token)),
+		(1 << 6) | (uint8(m.Type) << 4) | tknlen),
 		byte(m.Code),
 		tmpbuf[0], tmpbuf[1],
 	})
-	buf.Write(m.Token)
+
+    
+	buf.Write(m.Token[:tknlen])
 
 	/*
 	     0   1   2   3   4   5   6   7
@@ -437,6 +444,12 @@ func parseMessage(data []byte) (rv Message, err error) {
 	rv.MessageID = binary.BigEndian.Uint16(data[2:4])
 
 	b := data[4:]
+    
+    // Token
+    rv.Token = b[:tokenLen]
+    b = b[tokenLen:]
+
+
 	prev := 0
 	for len(b) > 0 {
 		if b[0] == 0xff {


### PR DESCRIPTION
Fix of issue 3.

Decode now actually decodes the token.
Encode makes sure token is of length 0-8 bytes. If the token is too long, it is truncated. A token length of 8 is written and first 8 bytes of token are written.
