### PR TITLE
use option's LONG format for whose value is just 15 bytes

### DIFF
--- a/message.go
+++ b/message.go
@@ -407,7 +407,7 @@ func (m *Message) encode() ([]byte, error) {
 	prev := 0
 	for _, o := range m.opts {
 		b := o.toBytes()
-		if len(b) > 15 {
+		if len(b) >= 15 {
 			buf.Write([]byte{
 				byte(int(o.ID)-prev)<<4 | 15,
 				byte(len(b) - 15),

--- a/message_test.go
+++ b/message_test.go
@@ -184,6 +184,54 @@ func TestEncodeSeveral(t *testing.T) {
 	}
 }
 
+func TestEncodePath14(t *testing.T) {
+	req := Message{
+		Type:      Confirmable,
+		Code:      GET,
+		MessageID: 12345,
+	}
+	req.SetPathString("123456789ABCDE")
+
+	data, err := req.encode()
+	if err != nil {
+		t.Fatalf("Error encoding request: %v", err)
+	}
+
+	// Inspected by hand.
+	exp := []byte{
+		0x40, 0x1, 0x30, 0x39, 0xbe,
+		'1', '2', '3', '4', '5', '6', '7', '8',
+		'9', 'A', 'B', 'C', 'D', 'E',
+	}
+	if !reflect.DeepEqual(exp, data) {
+		t.Fatalf("Expected\n%#v\ngot\n%#v", exp, data)
+	}
+}
+
+func TestEncodePath15(t *testing.T) {
+	req := Message{
+		Type:      Confirmable,
+		Code:      GET,
+		MessageID: 12345,
+	}
+	req.SetPathString("123456789ABCDEF")
+
+	data, err := req.encode()
+	if err != nil {
+		t.Fatalf("Error encoding request: %v", err)
+	}
+
+	// Inspected by hand.
+	exp := []byte{
+		0x40, 0x1, 0x30, 0x39, 0xbf, 0x00,
+		'1', '2', '3', '4', '5', '6', '7', '8',
+		'9', 'A', 'B', 'C', 'D', 'E', 'F',
+	}
+	if !reflect.DeepEqual(exp, data) {
+		t.Fatalf("Expected\n%#v\ngot\n%#v", exp, data)
+	}
+}
+
 func TestEncodeLargePath(t *testing.T) {
 	req := Message{
 		Type:      Confirmable,


### PR DESCRIPTION
**Problem**

When options (including path) have just 15 bytes value, `encode()` generates invalid sequence.

**Solution**

Use long form option, when length of option's value is 15 or more.

**Additional**

Added two tests for this.
