### PR TITLE
fix to pass decode tests

### DIFF
--- a/message.go
+++ b/message.go
@@ -486,6 +486,8 @@ func parseMessage(data []byte) (rv Message, err error) {
 		rv.opts = append(rv.opts, option)
 	}
 
-	rv.Payload = b
+	if len(b) > 0 {
+		rv.Payload = b
+	}
 	return rv, nil
 }


### PR DESCRIPTION
**Problem**

Two decode tests (TestDecodeLargePath and TestDecodeMessageSmaller) are failed with golang 1.3.

**Solution**

Don't set empty `[]byte` to Payload in `decode()`.
Default value for array/slide is nil.  It won't match empty array/slice.
