### PR TITLE
Fixing "panic: invalid type for option 8: []string ([])" bug in server example. 

### DIFF
--- a/example/server/coap_server.go
+++ b/example/server/coap_server.go
@@ -19,7 +19,7 @@ func main() {
 					Payload:   []byte("hello to you!"),
 				}
 				res.SetOption(coap.ContentFormat, coap.TextPlain)
-				res.SetOption(coap.LocationPath, m.Path())
+				res.SetPath(m.Path())
 
 				return res
 			}

--- a/message.go
+++ b/message.go
@@ -339,9 +339,9 @@ func (m *Message) SetPathString(s string) {
 
 // SetPath updates or adds a LocationPath attribute on this message.
 func (m *Message) SetPath(s []string) {
-	m.RemoveOption(URIPath)
+	m.RemoveOption(LocationPath)
 	for _, p := range s {
-		m.AddOption(URIPath, p)
+		m.AddOption(LocationPath, p)
 	}
 }
 


### PR DESCRIPTION
Adapting the SetPath function to their comment (setting LocationPath instead of URIPath)

Adapting server example to make use of the SetPath function instead of
setting the option directly. (Setting an array as options value failes
hence there is no such case in the toBytes function)

For repeating fields, it might be good to set the option in a for loop,
when receiving an array.
