### PR TITLE
first support for observe

### DIFF
--- a/example/obsclient/obsclient.go
+++ b/example/obsclient/obsclient.go
@@ -10,10 +10,11 @@ func main() {
 
 	req := coap.Message{
 		Type:      coap.NonConfirmable,
-		Code:      coap.SUBSCRIBE,
+		Code:      coap.GET,
 		MessageID: 12345,
 	}
 
+	req.AddOption(coap.Observe, 1)
 	req.SetPathString("/some/path")
 
 	c, err := coap.Dial("udp", "localhost:5683")

--- a/example/obsserver/obsserver.go
+++ b/example/obsserver/obsserver.go
@@ -38,8 +38,10 @@ func main() {
 	log.Fatal(coap.ListenAndServe("udp", ":5683",
 		coap.FuncHandler(func(l *net.UDPConn, a *net.UDPAddr, m *coap.Message) *coap.Message {
 			log.Printf("Got message path=%q: %#v from %v", m.Path(), m, a)
-			if m.Code == coap.SUBSCRIBE {
-				go periodicTransmitter(l, a, m)
+			if m.Code == coap.GET && m.Option(coap.Observe) != nil {
+				if value, ok := m.Option(coap.Observe).([]uint8); ok && len(value) >= 1 && value[0] == 1 {
+					go periodicTransmitter(l, a, m)
+				}
 			}
 			return nil
 		})))

--- a/message.go
+++ b/message.go
@@ -162,6 +162,7 @@ const (
 	URIHost       = OptionID(3)
 	ETag          = OptionID(4)
 	IfNoneMatch   = OptionID(5)
+	Observe       = OptionID(6) // draft-ietf-observe-16
 	URIPort       = OptionID(7)
 	LocationPath  = OptionID(8)
 	URIPath       = OptionID(11)
@@ -354,9 +355,9 @@ func (m *Message) RemoveOption(opID OptionID) {
 // AddOption adds an option.
 func (m *Message) AddOption(opID OptionID, val interface{}) {
 	iv := reflect.ValueOf(val)
-	if (iv.Kind() == reflect.Slice || iv.Kind() == reflect.Array)	&&
+	if (iv.Kind() == reflect.Slice || iv.Kind() == reflect.Array) &&
 		iv.Type().Elem().Kind() == reflect.String {
-		for i:=0; i < iv.Len(); i++ {
+		for i := 0; i < iv.Len(); i++ {
 			m.opts = append(m.opts, option{opID, iv.Index(i).Interface()})
 		}
 		return


### PR DESCRIPTION
 * removed old SUBSCRIBE action
 * added "observe" option as defined in the draft-ietf-observe-16 document
 * renamed and updated subserver and subclient examples to obsclient and obsserver

trying a smaller approach than #9 