### PR TITLE
Add error handler to client confirmable response.

### DIFF
--- a/client.go
+++ b/client.go
@@ -49,6 +49,9 @@ func (c *Conn) Send(req Message) (*Message, error) {
 	}
 
 	rv, err := Receive(c.conn, c.buf)
+    if err != nil {
+        return nil, err
+    }
 
 	return &rv, nil
 }


### PR DESCRIPTION
When using a confirmable call, if the client receives an error, it is not passed to the caller, but is ignored. This causes errors such as `udp read <ip-client> -> <ip-server> recvfrom: connection refused` and `udp read <ip-client> -> <ip-server> i/o timeout` to be passed back to the caller where the user can handle them as they see fit. Thoughs?
