### PR TITLE
Fix all MediaType constants to be of type MediaType instead of int

### DIFF
--- a/message.go
+++ b/message.go
@@ -179,11 +179,11 @@ type MediaType byte
 // Content types.
 const (
 	TextPlain     MediaType = 0  // text/plain;charset=utf-8
-	AppLinkFormat           = 40 // application/link-format
-	AppXML                  = 41 // application/xml
-	AppOctets               = 42 // application/octet-stream
-	AppExi                  = 47 // application/exi
-	AppJSON                 = 50 // application/json
+	AppLinkFormat MediaType = 40 // application/link-format
+	AppXML        MediaType = 41 // application/xml
+	AppOctets     MediaType = 42 // application/octet-stream
+	AppExi        MediaType = 47 // application/exi
+	AppJSON       MediaType = 50 // application/json
 )
 
 type option struct {


### PR DESCRIPTION
Before the fix only `coap.TextPlain` was of type `MediaType`; the other media type constants were of type `int`. The change is visible with the test program below.

Before the fix:

```
$ go run coap_types.go
coap.TextPlain type = %!t(coap.MediaType=0)
coap.AppXML type = %!t(int=41)
coap.AppJSON type =%!t(int=50)
```

After the fix:

```
$ go run coap_types.go
coap.TextPlain type = %!t(coap.MediaType=0)
coap.AppXML type = %!t(coap.MediaType=41)
coap.AppJSON type =%!t(coap.MediaType=50)
```

The test program:

```go
package main

import (
	"fmt"
	"github.com/dustin/go-coap"
)

func main() {
	fmt.Printf("coap.TextPlain type = %t\n", coap.TextPlain)
	fmt.Printf("coap.AppXML type = %t\n", coap.AppXML)
	fmt.Printf("coap.AppJSON type =%t\n", coap.AppJSON)
}
```
