### PR TITLE
UnmarshalBinary: cast ContentFormat value to MediaType

### DIFF
--- a/message.go
+++ b/message.go
@@ -551,7 +551,9 @@ func (m *Message) UnmarshalBinary(data []byte) error {
 
 		var opval interface{} = b[:length]
 		switch oid {
-		case URIPort, ContentFormat, MaxAge, Accept, Size1:
+		case ContentFormat, Accept:
+			opval = MediaType(decodeInt(b[:length]))
+		case URIPort, MaxAge, Size1:
 			opval = decodeInt(b[:length])
 		case URIHost, LocationPath, URIPath, URIQuery, LocationQuery,
 			ProxyURI, ProxyScheme:

--- a/message_test.go
+++ b/message_test.go
@@ -601,3 +601,24 @@ func TestErrorOptionMarker(t *testing.T) {
 		t.Errorf("Unexpected success parsing malformed option: %v", msg)
 	}
 }
+
+func TestDecodeContentFormatOptionToMediaType(t *testing.T) {
+	data := []byte{
+		0x40, 0x1, 0x30, 0x39, 0xc1, 0x32, 0x51, 0x29,
+	}
+
+	parsedMsg, err := parseMessage(data)
+	if err != nil {
+		t.Fatalf("Error parsing request: %v", err)
+	}
+
+	expected := "coap.MediaType"
+	actualContentFormatType := fmt.Sprintf("%T", parsedMsg.Option(ContentFormat))
+	if expected != actualContentFormatType {
+		t.Fatalf("Expected %#v got %#v", expected, actualContentFormatType)
+	}
+	actualAcceptType := fmt.Sprintf("%T", parsedMsg.Option(Accept))
+	if expected != actualAcceptType {
+		t.Fatalf("Expected %#v got %#v", expected, actualAcceptType)
+	}
+}


### PR DESCRIPTION
When parsing a CoAP message, the resulting ContentFormat option's value was of type uint32 instead of MediaType.

This fix (and test) sorts this for this option type.
