### PR TITLE
Add COAPType, COAPCode, OptionID type to all consts

### DIFF
--- a/message.go
+++ b/message.go
@@ -17,11 +17,11 @@ const (
 	// Confirmable messages require acknowledgements.
 	Confirmable COAPType = 0
 	// NonConfirmable messages do not require acknowledgements.
-	NonConfirmable = 1
+	NonConfirmable COAPType = 1
 	// Acknowledgement is a message indicating a response to confirmable message.
-	Acknowledgement = 2
+	Acknowledgement COAPType = 2
 	// Reset indicates a permanent negative acknowledgement.
-	Reset = 3
+	Reset COAPType = 3
 )
 
 var typeNames = [256]string{
@@ -49,34 +49,34 @@ type COAPCode uint8
 // Request Codes
 const (
 	GET    COAPCode = 1
-	POST            = 2
-	PUT             = 3
-	DELETE          = 4
+	POST   COAPCode = 2
+	PUT    COAPCode = 3
+	DELETE COAPCode = 4
 )
 
 // Response Codes
 const (
 	Created               COAPCode = 65
-	Deleted                        = 66
-	Valid                          = 67
-	Changed                        = 68
-	Content                        = 69
-	BadRequest                     = 128
-	Unauthorized                   = 129
-	BadOption                      = 130
-	Forbidden                      = 131
-	NotFound                       = 132
-	MethodNotAllowed               = 133
-	NotAcceptable                  = 134
-	PreconditionFailed             = 140
-	RequestEntityTooLarge          = 141
-	UnsupportedMediaType           = 143
-	InternalServerError            = 160
-	NotImplemented                 = 161
-	BadGateway                     = 162
-	ServiceUnavailable             = 163
-	GatewayTimeout                 = 164
-	ProxyingNotSupported           = 165
+	Deleted               COAPCode = 66
+	Valid                 COAPCode = 67
+	Changed               COAPCode = 68
+	Content               COAPCode = 69
+	BadRequest            COAPCode = 128
+	Unauthorized          COAPCode = 129
+	BadOption             COAPCode = 130
+	Forbidden             COAPCode = 131
+	NotFound              COAPCode = 132
+	MethodNotAllowed      COAPCode = 133
+	NotAcceptable         COAPCode = 134
+	PreconditionFailed    COAPCode = 140
+	RequestEntityTooLarge COAPCode = 141
+	UnsupportedMediaType  COAPCode = 143
+	InternalServerError   COAPCode = 160
+	NotImplemented        COAPCode = 161
+	BadGateway            COAPCode = 162
+	ServiceUnavailable    COAPCode = 163
+	GatewayTimeout        COAPCode = 164
+	ProxyingNotSupported  COAPCode = 165
 )
 
 var codeNames = [256]string{
@@ -156,21 +156,21 @@ type OptionID uint8
 // Option IDs.
 const (
 	IfMatch       OptionID = 1
-	URIHost                = 3
-	ETag                   = 4
-	IfNoneMatch            = 5
-	Observe                = 6
-	URIPort                = 7
-	LocationPath           = 8
-	URIPath                = 11
-	ContentFormat          = 12
-	MaxAge                 = 14
-	URIQuery               = 15
-	Accept                 = 17
-	LocationQuery          = 20
-	ProxyURI               = 35
-	ProxyScheme            = 39
-	Size1                  = 60
+	URIHost       OptionID = 3
+	ETag          OptionID = 4
+	IfNoneMatch   OptionID = 5
+	Observe       OptionID = 6
+	URIPort       OptionID = 7
+	LocationPath  OptionID = 8
+	URIPath       OptionID = 11
+	ContentFormat OptionID = 12
+	MaxAge        OptionID = 14
+	URIQuery      OptionID = 15
+	Accept        OptionID = 17
+	LocationQuery OptionID = 20
+	ProxyURI      OptionID = 35
+	ProxyScheme   OptionID = 39
+	Size1         OptionID = 60
 )
 
 // MediaType specifies the content type of a message.


### PR DESCRIPTION
Similar to #28.

I don't think adding unit-tests for this makes sense, but if you want me to add them (like you did in 0fab82afe2a86ec1d48738bcd5d21c4c7aa5bc5b for `MediaType`), I'll add to this pull request.
