### PR TITLE
Changed MediaType from byte to int to handle extended vendor type

### DIFF
--- a/message.go
+++ b/message.go
@@ -210,7 +210,7 @@ var optionDefs = [256]optionDef{
 }
 
 // MediaType specifies the content type of a message.
-type MediaType byte
+type MediaType int
 
 // Content types.
 const (


### PR DESCRIPTION
IETF is specifying MediaType codes beyond 255:
