### PR TITLE
Update CoAP / TCP: draft-ietf-core-coap-tcp-tls-06

### DIFF
--- a/messagetcp.go
+++ b/messagetcp.go
@@ -1,9 +1,18 @@
 package coap
 
 import (
+	"bytes"
 	"encoding/binary"
-	"errors"
+	"fmt"
 	"io"
+	"sort"
+)
+
+const (
+	TCP_MESSAGE_LEN13_BASE = 13
+	TCP_MESSAGE_LEN14_BASE = 269
+	TCP_MESSAGE_LEN15_BASE = 65805
+	TCP_MESSAGE_MAX_LEN    = 4295033101
 )
 
 // TcpMessage is a CoAP Message that can encode itself for TCP
@@ -13,57 +22,253 @@ type TcpMessage struct {
 }
 
 func (m *TcpMessage) MarshalBinary() ([]byte, error) {
-	bin, err := m.Message.MarshalBinary()
-	if err != nil {
-		return nil, err
-	}
-
 	/*
-		A CoAP TCP message looks like:
+	   A CoAP TCP message looks like:
 
-		     0                   1                   2                   3
-		    0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
-		   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-		   |        Message Length         |Ver| T |  TKL  |      Code     |
-		   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-		   |   Token (if any, TKL bytes) ...
-		   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-		   |   Options (if any) ...
-		   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-		   |1 1 1 1 1 1 1 1|    Payload (if any) ...
-		   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+	        0                   1                   2                   3
+	       0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+	      +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+	      |  Len  |  TKL  | Extended Length ...
+	      +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+	      |      Code     | TKL bytes ...
+	      +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+	      |   Options (if any) ...
+	      +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+	      |1 1 1 1 1 1 1 1|    Payload (if any) ...
+	      +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+
+	   The size of the Extended Length field is inferred from the value of the
+	   Len field as follows:
+
+	   | Len value  | Extended Length size  | Total length              |
+	   +------------+-----------------------+---------------------------+
+	   | 0-12       | 0                     | Len                       |
+	   | 13         | 1                     | Extended Length + 13      |
+	   | 14         | 2                     | Extended Length + 269     |
+	   | 15         | 4                     | Extended Length + 65805   |
 	*/
 
-	l := []byte{0, 0}
-	binary.BigEndian.PutUint16(l, uint16(len(bin)))
+	buf := bytes.Buffer{}
 
-	return append(l, bin...), nil
+	sort.Stable(&m.Message.opts)
+	writeOpts(&buf, m.Message.opts)
+
+	if len(m.Message.Payload) > 0 {
+		buf.Write([]byte{0xff})
+		buf.Write(m.Message.Payload)
+	}
+
+	var lenNib uint8
+	var extLenBytes []byte
+
+	if buf.Len() < TCP_MESSAGE_LEN14_BASE {
+		lenNib = uint8(buf.Len())
+	} else if buf.Len() < TCP_MESSAGE_LEN14_BASE {
+		lenNib = 13
+		extLen := buf.Len() - TCP_MESSAGE_LEN13_BASE
+		extLenBytes = []byte{uint8(extLen)}
+	} else if buf.Len() < TCP_MESSAGE_LEN15_BASE {
+		lenNib = 14
+		extLen := buf.Len() - TCP_MESSAGE_LEN14_BASE
+		extLenBytes = make([]byte, 2)
+		binary.BigEndian.PutUint16(extLenBytes, uint16(extLen))
+	} else if buf.Len() < TCP_MESSAGE_MAX_LEN {
+		lenNib = 15
+		extLen := buf.Len() - TCP_MESSAGE_LEN15_BASE
+		extLenBytes = make([]byte, 4)
+		binary.BigEndian.PutUint32(extLenBytes, uint32(extLen))
+	}
+
+	hdr := make([]byte, 1+len(extLenBytes)+len(m.Message.Token)+1)
+	hdrOff := 0
+
+	// Length and TKL nibbles.
+	hdr[hdrOff] = uint8(0xf&len(m.Token)) | (lenNib << 4)
+	hdrOff++
+
+	// Extended length, if present.
+	if len(extLenBytes) > 0 {
+		copy(hdr[hdrOff:hdrOff+len(extLenBytes)], extLenBytes)
+		hdrOff += len(extLenBytes)
+	}
+
+	// Code.
+	hdr[hdrOff] = byte(m.Message.Code)
+	hdrOff++
+
+	// Token.
+	if len(m.Message.Token) > 0 {
+		copy(hdr[hdrOff:hdrOff+len(m.Message.Token)], m.Message.Token)
+		hdrOff += len(m.Message.Token)
+	}
+
+	return append(hdr, buf.Bytes()...), nil
+}
+
+// msgTcpInfo describes a single TCP CoAP message.  Used during reassembly.
+type msgTcpInfo struct {
+	typ    uint8
+	token  []byte
+	code   uint8
+	hdrLen int
+	totLen int
+}
+
+// readTcpMsgInfo infers information about a TCP CoAP message from the first
+// fragment.
+func readTcpMsgInfo(r io.Reader) (msgTcpInfo, error) {
+	mti := msgTcpInfo{}
+
+	hdrOff := 0
+
+	var firstByte byte
+	if err := binary.Read(r, binary.BigEndian, &firstByte); err != nil {
+		return mti, err
+	}
+	hdrOff++
+
+	lenNib := (firstByte & 0xf0) >> 4
+	tkl := firstByte & 0x0f
+
+	var opLen int
+	if lenNib < TCP_MESSAGE_LEN13_BASE {
+		opLen = int(lenNib)
+	} else if lenNib == 13 {
+		var extLen byte
+		if err := binary.Read(r, binary.BigEndian, &extLen); err != nil {
+			return mti, err
+		}
+		hdrOff++
+		opLen = TCP_MESSAGE_LEN13_BASE + int(extLen)
+	} else if lenNib == 14 {
+		var extLen uint16
+		if err := binary.Read(r, binary.BigEndian, &extLen); err != nil {
+			return mti, err
+		}
+		hdrOff += 2
+		opLen = TCP_MESSAGE_LEN14_BASE + int(extLen)
+	} else if lenNib == 15 {
+		var extLen uint32
+		if err := binary.Read(r, binary.BigEndian, &extLen); err != nil {
+			return mti, err
+		}
+		hdrOff += 4
+		opLen = TCP_MESSAGE_LEN15_BASE + int(extLen)
+	}
+
+	mti.totLen = hdrOff + 1 + int(tkl) + opLen
+
+	if err := binary.Read(r, binary.BigEndian, &mti.code); err != nil {
+		return mti, err
+	}
+	hdrOff++
+
+	mti.token = make([]byte, tkl)
+	if _, err := io.ReadFull(r, mti.token); err != nil {
+		return mti, err
+	}
+	hdrOff += int(tkl)
+
+	mti.hdrLen = hdrOff
+
+	return mti, nil
+}
+
+func readTcpMsgBody(mti msgTcpInfo, r io.Reader) (options, []byte, error) {
+	bodyLen := mti.totLen - mti.hdrLen
+	b := make([]byte, bodyLen)
+	if _, err := io.ReadFull(r, b); err != nil {
+		return nil, nil, err
+	}
+
+	o, p, err := parseBody(b)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return o, p, nil
+}
+
+func (m *TcpMessage) fill(mti msgTcpInfo, o options, p []byte) {
+	m.Type = COAPType(mti.typ)
+	m.Code = COAPCode(mti.code)
+	m.Token = mti.token
+	m.opts = o
+	m.Payload = p
 }
 
 func (m *TcpMessage) UnmarshalBinary(data []byte) error {
-	if len(data) < 4 {
-		return errors.New("short packet")
+	r := bytes.NewReader(data)
+
+	mti, err := readTcpMsgInfo(r)
+	if err != nil {
+		return fmt.Errorf("Error reading TCP CoAP header; %s", err.Error())
 	}
 
-	return m.Message.UnmarshalBinary(data)
+	if len(data) != mti.totLen {
+		return fmt.Errorf("CoAP length mismatch (hdr=%d pkt=%d)",
+			mti.totLen, len(data))
+	}
+
+	o, p, err := readTcpMsgBody(mti, r)
+	if err != nil {
+		return err
+	}
+
+	m.fill(mti, o, p)
+	return nil
+}
+
+// PullTcp extracts a complete TCP CoAP message from the front of a byte queue.
+//
+// Return values:
+//  *TcpMessage: On success, points to the extracted message; nil if a complete
+//               message could not be extracted.
+//  []byte: The unread portion of of the supplied byte buffer.  If a message
+//          was not extracted, this is the unchanged buffer that was passed in.
+//  error: Non-nil if the buffer contains an invalid CoAP message.
+//
+// Note: It is not an error if the supplied buffer does not contain a complete
+// message.  In such a case, nil *TclMessage and error values are returned
+// along with the original buffer.
+func PullTcp(data []byte) (*TcpMessage, []byte, error) {
+	r := bytes.NewReader(data)
+	m, err := Decode(r)
+	if err != nil {
+		if err == io.EOF {
+			// Packet is incomplete.
+			return nil, data, nil
+		} else {
+			// Some other error.
+			return nil, data, err
+		}
+	}
+
+	// Determine the number of bytes read.  These bytes get trimmed from the
+	// front of the returned data slice.
+	sz, err := r.Seek(0, io.SeekCurrent)
+	if err != nil {
+		// This should never happen.
+		return nil, data, err
+	}
+
+	return m, data[sz:], nil
 }
 
 // Decode reads a single message from its input.
 func Decode(r io.Reader) (*TcpMessage, error) {
-	var ln uint16
-	err := binary.Read(r, binary.BigEndian, &ln)
+	mti, err := readTcpMsgInfo(r)
 	if err != nil {
 		return nil, err
 	}
 
-	packet := make([]byte, ln)
-	_, err = io.ReadFull(r, packet)
+	o, p, err := readTcpMsgBody(mti, r)
 	if err != nil {
 		return nil, err
 	}
 
-	m := TcpMessage{}
+	m := &TcpMessage{}
+	m.fill(mti, o, p)
 
-	err = m.UnmarshalBinary(packet)
-	return &m, err
+	return m, nil
 }

--- a/messagetcp.go
+++ b/messagetcp.go
@@ -246,7 +246,8 @@ func PullTcp(data []byte) (*TcpMessage, []byte, error) {
 
 	// Determine the number of bytes read.  These bytes get trimmed from the
 	// front of the returned data slice.
-	sz, err := r.Seek(0, io.SeekCurrent)
+	// XXX: Replace "1" with io.SeekCurrent when go 1.7 becomes mainstream.
+	sz, err := r.Seek(0, 1)
 	if err != nil {
 		// This should never happen.
 		return nil, data, err

--- a/messagetcp_test.go
+++ b/messagetcp_test.go
@@ -2,18 +2,19 @@ package coap
 
 import (
 	"bytes"
-	"encoding/binary"
 	"testing"
 )
 
 func TestTCPDecodeMessageSmallWithPayload(t *testing.T) {
-	input := []byte{0, 0,
-		0x40, 0x1, 0x30, 0x39, 0x21, 0x3,
+	input := []byte{
+		13 << 4, // len=13, tkl=0
+		0x01,    // Extended Length
+		0x01,    // Code
+		0x30, 0x39, 0x21, 0x3,
 		0x26, 0x77, 0x65, 0x65, 0x74, 0x61, 0x67,
-		0xff, 'h', 'i',
+		0xff,
+		'h', 'i',
 	}
-
-	binary.BigEndian.PutUint16(input, uint16(len(input)-2))
 
 	msg, err := Decode(bytes.NewReader(input))
 	if err != nil {
@@ -25,9 +26,6 @@ func TestTCPDecodeMessageSmallWithPayload(t *testing.T) {
 	}
 	if msg.Code != GET {
 		t.Errorf("Expected message code GET, got %v", msg.Code)
-	}
-	if msg.MessageID != 12345 {
-		t.Errorf("Expected message ID 12345, got %v", msg.MessageID)
 	}
 
 	if !bytes.Equal(msg.Payload, []byte("hi")) {


### PR DESCRIPTION
I wasn't able to find a specification for the CoAP TCP header that this library uses (2-byte length followed by standard CoAP header).  Perhaps this is from an old standard?  The only specification I am familiar with for CoAP over TCP is this one: https://tools.ietf.org/html/draft-ietf-core-coap-tcp-tls-06.

If you are interested in this pull request, I don't mind making any stylistic changes you would like to see.

This commit incorporates the modified CoAP header for TCP, as defined in
https://tools.ietf.org/html/draft-ietf-core-coap-tcp-tls-06.