### PR TITLE
Change ServeMux.Handle() from http to coap

### DIFF
--- a/servmux.go
+++ b/servmux.go
@@ -78,10 +78,13 @@ func (mux *ServeMux) Handle(pattern string, handler Handler) {
 	}
 
 	if pattern == "" {
-		panic("http: invalid pattern " + pattern)
+		panic("coap: invalid pattern " + pattern)
 	}
 	if handler == nil {
-		panic("http: nil handler")
+		panic("coap: nil handler")
+	}
+	if _, ok := mux.m[pattern]; ok {
+		panic("coap: multiple registration for " + pattern)
 	}
 
 	mux.m[pattern] = muxEntry{h: handler, pattern: pattern}


### PR DESCRIPTION
go-coap is a library of coap, not http. ServeMux.Handle() will panic a
message like "http: xxx", it make user confuse when using both coap and
http, so change word "http" to "coap".

ServeMux.Handle() must has been copied from net/http, also, a pattern
can only be registered once, maybe.