### PR TITLE
Support block wise transfer options

### DIFF
--- a/message.go
+++ b/message.go
@@ -173,6 +173,11 @@ const (
 	Size1         OptionID = 60
 )
 
+// Block-Wise Transfer Option IDs (RFC7959 section 6.).
+const (
+	Block2 OptionID = 23
+)
+
 // Option value format (RFC7252 section 3.2)
 type valueFormat uint8
 
@@ -207,6 +212,7 @@ var optionDefs = [256]optionDef{
 	ProxyURI:      optionDef{valueFormat: valueString, minLen: 1, maxLen: 1034},
 	ProxyScheme:   optionDef{valueFormat: valueString, minLen: 1, maxLen: 255},
 	Size1:         optionDef{valueFormat: valueUint, minLen: 0, maxLen: 4},
+	Block2:        optionDef{valueFormat: valueUint, minLen: 0, maxLen: 3},
 }
 
 // MediaType specifies the content type of a message.
@@ -348,6 +354,39 @@ type Message struct {
 // IsConfirmable returns true if this message is confirmable.
 func (m Message) IsConfirmable() bool {
 	return m.Type == Confirmable
+}
+
+// IsBlock2 returns true if this message contains Block2 option.
+func (m Message) IsBlock2() bool {
+	val, ok := m.Option(Block2).(uint32)
+	if !ok {
+		return false
+	}
+	return val > 0
+}
+
+// Block2 returns a block number and size of the block requested.
+func (m Message) Block2() (uint32, uint32, bool) {
+	val, ok := m.Option(Block2).(uint32)
+	if !ok {
+		return 0, 0, false
+	}
+	num := val / 16
+	szx := (val & 7) + 4
+	more := false
+	if val&8 > 0 {
+		more = true
+	}
+	return num, szx, more
+}
+
+// SetBlock2 sets Block2 option.
+func (m *Message) SetBlock2(num, szx uint32, more bool) {
+	val := (num * 16) | (szx - 4)
+	if more {
+		val |= 8
+	}
+	m.SetOption(Block2, val)
 }
 
 // Options gets all the values for the given option.

--- a/message.go
+++ b/message.go
@@ -79,32 +79,40 @@ const (
 	ProxyingNotSupported  COAPCode = 165
 )
 
+// Response Codes for Block-Wise Transfer in CoAP (RFC 7959)
+const (
+	Continue                COAPCode = 95
+	RequestEntityIncomplete COAPCode = 136
+)
+
 var codeNames = [256]string{
-	GET:                   "GET",
-	POST:                  "POST",
-	PUT:                   "PUT",
-	DELETE:                "DELETE",
-	Created:               "Created",
-	Deleted:               "Deleted",
-	Valid:                 "Valid",
-	Changed:               "Changed",
-	Content:               "Content",
-	BadRequest:            "BadRequest",
-	Unauthorized:          "Unauthorized",
-	BadOption:             "BadOption",
-	Forbidden:             "Forbidden",
-	NotFound:              "NotFound",
-	MethodNotAllowed:      "MethodNotAllowed",
-	NotAcceptable:         "NotAcceptable",
-	PreconditionFailed:    "PreconditionFailed",
-	RequestEntityTooLarge: "RequestEntityTooLarge",
-	UnsupportedMediaType:  "UnsupportedMediaType",
-	InternalServerError:   "InternalServerError",
-	NotImplemented:        "NotImplemented",
-	BadGateway:            "BadGateway",
-	ServiceUnavailable:    "ServiceUnavailable",
-	GatewayTimeout:        "GatewayTimeout",
-	ProxyingNotSupported:  "ProxyingNotSupported",
+	GET:                     "GET",
+	POST:                    "POST",
+	PUT:                     "PUT",
+	DELETE:                  "DELETE",
+	Created:                 "Created",
+	Deleted:                 "Deleted",
+	Valid:                   "Valid",
+	Changed:                 "Changed",
+	Content:                 "Content",
+	BadRequest:              "BadRequest",
+	Unauthorized:            "Unauthorized",
+	BadOption:               "BadOption",
+	Forbidden:               "Forbidden",
+	NotFound:                "NotFound",
+	MethodNotAllowed:        "MethodNotAllowed",
+	NotAcceptable:           "NotAcceptable",
+	PreconditionFailed:      "PreconditionFailed",
+	RequestEntityTooLarge:   "RequestEntityTooLarge",
+	UnsupportedMediaType:    "UnsupportedMediaType",
+	InternalServerError:     "InternalServerError",
+	NotImplemented:          "NotImplemented",
+	BadGateway:              "BadGateway",
+	ServiceUnavailable:      "ServiceUnavailable",
+	GatewayTimeout:          "GatewayTimeout",
+	ProxyingNotSupported:    "ProxyingNotSupported",
+	Continue:                "Continue",
+	RequestEntityIncomplete: "Request Entity Incomplete",
 }
 
 func init() {
@@ -176,6 +184,7 @@ const (
 // Block-Wise Transfer Option IDs (RFC7959 section 6.).
 const (
 	Block2 OptionID = 23
+	Block1 OptionID = 27
 )
 
 // Option value format (RFC7252 section 3.2)
@@ -213,6 +222,7 @@ var optionDefs = [256]optionDef{
 	ProxyScheme:   optionDef{valueFormat: valueString, minLen: 1, maxLen: 255},
 	Size1:         optionDef{valueFormat: valueUint, minLen: 0, maxLen: 4},
 	Block2:        optionDef{valueFormat: valueUint, minLen: 0, maxLen: 3},
+	Block1:        optionDef{valueFormat: valueUint, minLen: 0, maxLen: 3},
 }
 
 // MediaType specifies the content type of a message.
@@ -365,9 +375,45 @@ func (m Message) IsBlock2() bool {
 	return val > 0
 }
 
-// Block2 returns a block number and size of the block requested.
+// Block2 returns a block number, the block size and true when other blocks follow.
 func (m Message) Block2() (uint32, uint32, bool) {
-	val, ok := m.Option(Block2).(uint32)
+	return m.decodeBlock(Block2)
+}
+
+// SetBlock2 sets Block2 option.
+func (m *Message) SetBlock2(num, szx uint32, more bool) {
+	m.encodeBlock(Block2, num, szx, more)
+}
+
+// IsBlock2 returns true if this message contains Block2 option.
+func (m Message) IsBlock1() bool {
+	val, ok := m.Option(Block1).(uint32)
+	if !ok {
+		return false
+	}
+	return val > 0
+}
+
+// Block1 returns a block number, the block size and true when other blocks follow.
+func (m Message) Block1() (uint32, uint32, bool) {
+	return m.decodeBlock(Block1)
+}
+
+// SetBlock1 sets Block1 option.
+func (m *Message) SetBlock1(num, szx uint32, more bool) {
+	m.encodeBlock(Block1, num, szx, more)
+}
+
+func (m *Message) encodeBlock(blockType OptionID, num, szx uint32, more bool) {
+	val := (num * 16) | (szx - 4)
+	if more {
+		val |= 8
+	}
+	m.SetOption(blockType, val)
+}
+
+func (m Message) decodeBlock(blockType OptionID) (uint32, uint32, bool) {
+	val, ok := m.Option(blockType).(uint32)
 	if !ok {
 		return 0, 0, false
 	}
@@ -378,15 +424,6 @@ func (m Message) Block2() (uint32, uint32, bool) {
 		more = true
 	}
 	return num, szx, more
-}
-
-// SetBlock2 sets Block2 option.
-func (m *Message) SetBlock2(num, szx uint32, more bool) {
-	val := (num * 16) | (szx - 4)
-	if more {
-		val |= 8
-	}
-	m.SetOption(Block2, val)
 }
 
 // Options gets all the values for the given option.

--- a/message_test.go
+++ b/message_test.go
@@ -807,6 +807,55 @@ func TestEncodeMessageWithAllOptions(t *testing.T) {
 	assertEqualMessages(t, req, parsedMsg)
 }
 
+func TestEncodeMessageWithBlock1(t *testing.T) {
+	req := Message{
+		Type:      Confirmable,
+		Code:      GET,
+		MessageID: 12345,
+	}
+
+	if req.IsBlock1() {
+		t.Fatalf("Error Block1 FOUND in request")
+	}
+
+	blockNum := uint32(0)
+	blockSzx := uint32(10)
+	blockMore := true
+
+	req.SetBlock1(blockNum, blockSzx, blockMore)
+
+	if !req.IsBlock1() {
+		t.Fatalf("Error Block1 NOT FOUND in request")
+	}
+
+	data, err := req.MarshalBinary()
+	if err != nil {
+		t.Fatalf("Error encoding request: %v", err)
+	}
+
+	res, err := ParseMessage(data)
+	if err != nil {
+		t.Fatalf("Error parsing binary packet: %v", err)
+	}
+	assertEqualMessages(t, req, res)
+
+	if !res.IsBlock1() {
+		t.Fatalf("Error Block1 NOT FOUND in response")
+	}
+
+	resBlockNum, resBlockSzx, resBlockMore := res.Block1()
+
+	if resBlockNum != blockNum {
+		t.Fatalf("Error block NUM %d != %d", blockNum, resBlockNum)
+	}
+	if resBlockSzx != blockSzx {
+		t.Fatalf("Error block SZX %d != %d", blockSzx, resBlockSzx)
+	}
+	if resBlockMore != blockMore {
+		t.Fatalf("Error block more %v != %v", blockMore, resBlockMore)
+	}
+}
+
 func TestEncodeMessageWithBlock2(t *testing.T) {
 	req := Message{
 		Type:      Confirmable,
@@ -853,5 +902,82 @@ func TestEncodeMessageWithBlock2(t *testing.T) {
 	}
 	if resBlockMore != blockMore {
 		t.Fatalf("Error block more %v != %v", blockMore, resBlockMore)
+	}
+}
+
+func TestEncodeMessageWithBlockOptions(t *testing.T) {
+	req := Message{
+		Type:      Confirmable,
+		Code:      GET,
+		MessageID: 12345,
+	}
+
+	if req.IsBlock1() {
+		t.Fatalf("Error Block1 FOUND in request")
+	}
+	if req.IsBlock2() {
+		t.Fatalf("Error Block2 FOUND in request")
+	}
+
+	block1Num := uint32(0)
+	block1Szx := uint32(10)
+	block1More := true
+
+	req.SetBlock1(block1Num, block1Szx, block1More)
+
+	if !req.IsBlock1() {
+		t.Fatalf("Error Block1 NOT FOUND in request")
+	}
+
+	block2Num := uint32(0)
+	block2Szx := uint32(10)
+	block2More := false
+
+	req.SetBlock2(block2Num, block2Szx, block2More)
+
+	if !req.IsBlock2() {
+		t.Fatalf("Error Block2 NOT FOUND in request")
+	}
+
+	data, err := req.MarshalBinary()
+	if err != nil {
+		t.Fatalf("Error encoding request: %v", err)
+	}
+
+	res, err := ParseMessage(data)
+	if err != nil {
+		t.Fatalf("Error parsing binary packet: %v", err)
+	}
+	assertEqualMessages(t, req, res)
+
+	if !res.IsBlock1() {
+		t.Fatalf("Error Block1 NOT FOUND in response")
+	}
+	if !res.IsBlock2() {
+		t.Fatalf("Error Block2 NOT FOUND in response")
+	}
+
+	resBlock1Num, resBlock1Szx, resBlock1More := res.Block1()
+
+	if resBlock1Num != block1Num {
+		t.Fatalf("Error block1 NUM %d != %d", block1Num, resBlock1Num)
+	}
+	if resBlock1Szx != block1Szx {
+		t.Fatalf("Error block1 SZX %d != %d", block1Szx, resBlock1Szx)
+	}
+	if resBlock1More != block1More {
+		t.Fatalf("Error block1 more %v != %v", block1More, resBlock1More)
+	}
+
+	resBlock2Num, resBlock2Szx, resBlock2More := res.Block2()
+
+	if resBlock2Num != block2Num {
+		t.Fatalf("Error block2 NUM %d != %d", block2Num, resBlock2Num)
+	}
+	if resBlock2Szx != block2Szx {
+		t.Fatalf("Error block2 SZX %d != %d", block2Szx, resBlock2Szx)
+	}
+	if resBlock2More != block2More {
+		t.Fatalf("Error block2 more %v != %v", block2More, resBlock2More)
 	}
 }

--- a/message_test.go
+++ b/message_test.go
@@ -806,3 +806,52 @@ func TestEncodeMessageWithAllOptions(t *testing.T) {
 	}
 	assertEqualMessages(t, req, parsedMsg)
 }
+
+func TestEncodeMessageWithBlock2(t *testing.T) {
+	req := Message{
+		Type:      Confirmable,
+		Code:      GET,
+		MessageID: 12345,
+	}
+
+	if req.IsBlock2() {
+		t.Fatalf("Error Block2 FOUND in request")
+	}
+
+	blockNum := uint32(0)
+	blockSzx := uint32(10)
+	blockMore := false
+
+	req.SetBlock2(blockNum, blockSzx, blockMore)
+
+	if !req.IsBlock2() {
+		t.Fatalf("Error Block2 NOT FOUND in request")
+	}
+
+	data, err := req.MarshalBinary()
+	if err != nil {
+		t.Fatalf("Error encoding request: %v", err)
+	}
+
+	res, err := ParseMessage(data)
+	if err != nil {
+		t.Fatalf("Error parsing binary packet: %v", err)
+	}
+	assertEqualMessages(t, req, res)
+
+	if !res.IsBlock2() {
+		t.Fatalf("Error Block2 NOT FOUND in response")
+	}
+
+	resBlockNum, resBlockSzx, resBlockMore := res.Block2()
+
+	if resBlockNum != blockNum {
+		t.Fatalf("Error block NUM %d != %d", blockNum, resBlockNum)
+	}
+	if resBlockSzx != blockSzx {
+		t.Fatalf("Error block SZX %d != %d", blockSzx, resBlockSzx)
+	}
+	if resBlockMore != blockMore {
+		t.Fatalf("Error block more %v != %v", blockMore, resBlockMore)
+	}
+}


### PR DESCRIPTION
This PR adds helper methods to check/get/set Block1 and Block2 options as defined in RFC 7959[0].

[0] https://tools.ietf.org/html/rfc7959